### PR TITLE
Adopt correct failed-ish continuation behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid diagnostic hack for messages ([#177](https://github.com/cucumber/cucumber-node/pull/177))
 - Use retainLines option when generating code ([#182](https://github.com/cucumber/cucumber-node/pull/182))
 
+### Fixed
+- Adopt correct failed-ish continuation behaviour ([#241](https://github.com/cucumber/cucumber-node/pull/241))
+
 ## [0.6.1] - 2025-12-14
 ### Fixed
 - Handle async parameter type transformers ([#169](https://github.com/cucumber/cucumber-node/pull/169))

--- a/src/runner/ExecutableTestCase.ts
+++ b/src/runner/ExecutableTestCase.ts
@@ -10,7 +10,7 @@ import { makeAttachment, makeLink, makeLog } from './makeAttachment.js'
 
 export class ExecutableTestCase {
   readonly id = newId()
-  outcomeKnown = false
+  outcome: 'unknown' | 'failedish' | 'skipped' = 'unknown'
   private attachmentsSupport?: AttachmentsSupport
   private world?: World
   private currentTestStepId?: string

--- a/src/runner/ExecutableTestStep.ts
+++ b/src/runner/ExecutableTestStep.ts
@@ -4,10 +4,13 @@ import { styleText } from 'node:util'
 import { highlight } from '@babel/code-frame'
 import {
   AmbiguousError,
+  type AmbiguousStep,
   type AssembledTestStep,
   DataTable,
+  type PreparedStep,
   type SupportCodeLibrary,
   UndefinedError,
+  type UndefinedStep,
 } from '@cucumber/core'
 import type { TestStepResult } from '@cucumber/messages'
 
@@ -19,12 +22,16 @@ import type { MessagesCollector } from './MessagesCollector.js'
 import { makeSnippets } from './makeSnippets.js'
 
 export class ExecutableTestStep {
+  private readonly prepared: PreparedStep | UndefinedStep | AmbiguousStep
+
   constructor(
     private readonly messages: MessagesCollector,
     private readonly testCase: ExecutableTestCase,
     private readonly supportCodeLibrary: SupportCodeLibrary,
     private readonly assembledStep: AssembledTestStep
-  ) {}
+  ) {
+    this.prepared = assembledStep.prepare()
+  }
 
   get name(): string {
     return [styleText('bold', this.assembledStep.name.prefix), this.assembledStep.name.body]
@@ -33,7 +40,17 @@ export class ExecutableTestStep {
   }
 
   get options() {
-    return { skip: this.testCase.outcomeKnown && !this.assembledStep.always }
+    if (this.assembledStep.always) {
+      return { skip: false }
+    }
+    switch (this.testCase.outcome) {
+      case 'skipped':
+        return { skip: true }
+      case 'failedish':
+        return { skip: this.prepared.type === 'prepared' }
+      default:
+        return { skip: false }
+    }
   }
 
   async setup() {
@@ -49,7 +66,7 @@ export class ExecutableTestStep {
   async execute(nodeTestContext: TestContext) {
     let success = false
     try {
-      const prepared = this.assembledStep.prepare()
+      const prepared = this.prepared
 
       if (prepared.type === 'undefined') {
         const snippets = makeSnippets(prepared.pickleStep, this.supportCodeLibrary)
@@ -91,7 +108,7 @@ export class ExecutableTestStep {
       success = true
     } finally {
       if (!success) {
-        this.testCase.outcomeKnown = true
+        this.markFailedish()
       }
     }
   }
@@ -102,13 +119,19 @@ export class ExecutableTestStep {
       mock: nodeTestContext.mock,
       skip: () => {
         nodeTestContext.skip()
-        this.testCase.outcomeKnown = true
+        this.testCase.outcome = 'skipped'
       },
       todo: () => {
         nodeTestContext.todo()
-        this.testCase.outcomeKnown = true
+        this.markFailedish()
       },
       ...this.testCase.context,
+    }
+  }
+
+  private markFailedish() {
+    if (this.testCase.outcome === 'unknown') {
+      this.testCase.outcome = 'failedish'
     }
   }
 

--- a/test/cck/cck.spec.ts
+++ b/test/cck/cck.spec.ts
@@ -45,8 +45,6 @@ const CCK_PATH = path.join(process.cwd(), 'node_modules', '@cucumber', 'compatib
 const UNSUPPORTED = [
   // not a test sample
   'all-statuses',
-  // TODO implement failed-ish step semantics
-  'failedish-combinations',
   // we don't support global hooks yet
   'global-hooks',
   'global-hooks-attachments',

--- a/test/cck/failedish-combinations/support.mjs
+++ b/test/cck/failedish-combinations/support.mjs
@@ -1,0 +1,17 @@
+import { Given } from '@cucumber/node'
+
+Given(/^a step$/, () => {
+  // no-op
+})
+
+Given(/^a skipped step$/, (t) => t.skip())
+
+Given(/^a pending step$/, (t) => t.todo())
+
+Given(/^an ambiguous (.*?)$/, () => {})
+
+Given(/^(.*?) ambiguous step$/, () => {})
+
+Given(/^a failing step$/, () => {
+  throw new Error('whoops')
+})


### PR DESCRIPTION
### 🤔 What's changed?

When the overall status of the test case is already "failed-ish" - i.e. not passing or skipped, continue to mark pickle steps as undefined or ambiguous rather than just blindly skipping.

### ⚡️ What's your motivation? 

Adopts the behaviour encoded in https://github.com/cucumber/compatibility-kit/pull/239.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
